### PR TITLE
Version 2.0.15 take 2

### DIFF
--- a/Changelog-20x.md
+++ b/Changelog-20x.md
@@ -9,6 +9,7 @@ Date: 2021-04-07
 * issue [#42](https://github.com/HL7Norway/basisprofiler-r4/issues/42)
 * `no-basis-relatedperson-person-reference` Added extension to add person reference to the RelatedPerson.patient element
 * `no-basis-RelatedPerson` Removed reference to no-basis-Person and Person from RelatedPerson.patient
+* `no-basis-RelatedPerson-Ærlend-Sørgård-person-extension.xml` Added example to demonstrate the use of the new extension
 
 Date: 2021-01-15
 

--- a/Changelog-20x.md
+++ b/Changelog-20x.md
@@ -6,6 +6,7 @@
 
 Date: 2021-04-07
 
+* issue [#42](https://github.com/HL7Norway/basisprofiler-r4/issues/42)
 * `no-basis-relatedperson-person-reference` Added extension to add person reference to the RelatedPerson.patient element
 * `no-basis-RelatedPerson` Removed reference to no-basis-Person and Person from RelatedPerson.patient
 

--- a/Changelog-20x.md
+++ b/Changelog-20x.md
@@ -4,6 +4,11 @@
 
 ### Version 2.0.15
 
+Date: 2021-04-07
+
+* `no-basis-relatedperson-person-reference` Added extension to add person reference to the RelatedPerson.patient element
+* `no-basis-RelatedPerson` Removed reference to no-basis-Person and Person from RelatedPerson.patient
+
 Date: 2021-01-15
 
 * `no-basis-Organization` Added slices for 8624 og 8628, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)

--- a/Changelog-20x.md
+++ b/Changelog-20x.md
@@ -10,10 +10,11 @@ Date: 2021-04-07
 * `no-basis-relatedperson-person-reference` Added extension to add person reference to the RelatedPerson.patient element
 * `no-basis-RelatedPerson` Removed reference to no-basis-Person and Person from RelatedPerson.patient
 * `no-basis-RelatedPerson-Ærlend-Sørgård-person-extension.xml` Added example to demonstrate the use of the new extension
+* `no-basis-Organization` Added slices for 8624, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)
 
 Date: 2021-01-15
 
-* `no-basis-Organization` Added slices for 8624 og 8628, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)
+* `no-basis-Organization` Added slices for 8628, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)
 
 Date: 2021-01-12
 

--- a/Changelog-20x.md
+++ b/Changelog-20x.md
@@ -4,6 +4,10 @@
 
 ### Version 2.0.15
 
+Date: 2021-01-15
+
+* `no-basis-Organization` Added slices for 8624 og 8628, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)
+
 Date: 2021-01-12
 
 * `no-basis-kommunenummer.namingsystem` Added oid value as possible uniqueId for kommunenummer

--- a/Examples/no-basis-RelatedPerson-Ærlend-Sørgård-person-extension.xml
+++ b/Examples/no-basis-RelatedPerson-Ærlend-Sørgård-person-extension.xml
@@ -1,0 +1,46 @@
+<RelatedPerson xmlns="http://hl7.org/fhir">
+	<meta>
+		<profile value="http://hl7.no/fhir/StructureDefinition/no-basis-RelatedPerson"/>
+	</meta>
+	<extension url="http://hl7.no/fhir/StructureDefinition/no-basis-person-citizenship">
+		<extension url="code">
+			<valueCodeableConcept>
+				<coding>
+					<system value="urn:iso:std:iso:3166" />
+                    <code value="NO" />
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+	</extension>
+	<identifier>
+		<system value="urn:oid:2.16.578.1.12.4.1.4.1"/>
+		<value value="05073500186"/>
+	</identifier>
+	<patient>
+		<extension url="http://ehelse.no/fhir/StructureDefinition/no-basis-relatedperson-person-reference">
+			<valueReference>
+				<identifier>
+					<system value="urn:oid:2.16.578.1.12.4.1.4.1"/>
+					<value value="04021950128"/>
+				</identifier>
+			</valueReference>
+		</extension>
+		<identifier>
+			<system value="urn:oid:2.16.578.1.12.4.1.4.1" />
+			<value value="04021950128" />
+		</identifier>
+	</patient>
+	<relationship>
+		<coding>
+			<system value="http://hl7.no/fhir/CodeSystem/no-basis-marital-status"/>
+			<code value="gift"/>
+		</coding>
+	</relationship>
+	<name>
+		<extension url="http://hl7.no/fhir/StructureDefinition/no-basis-middlename">
+			<valueString value="Pårørende"/>
+		</extension>
+		<family value="Sørgård"/>
+		<given value="Ærlend"/>
+	</name>
+</RelatedPerson>

--- a/StructureDefinition/no-basis-Organization.structuredefinition-profile.xml
+++ b/StructureDefinition/no-basis-Organization.structuredefinition-profile.xml
@@ -59,6 +59,34 @@
       <path value="Organization.identifier.value" />
       <min value="1" />
     </element>
+    <element id="Organization.type">
+      <path value="Organization.type" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <definition value="no-basis provides two commonly used slices to indicate Organization.type. Both ValueSets are used in the Norweian realm and is currently maintained at Volven.no: &#xD;&#xA;- Organisatorisk nivå (OID=8628)&#xD;&#xA;- Organisatorisk betegnelse (OID=8624)&#xD;&#xA;&#xD;&#xA;The kind(s) of organization that this is." />
+    </element>
+    <element id="Organization.type:organisatoriskNiva">
+      <path value="Organization.type" />
+      <sliceName value="organisatoriskNiva" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="urn:oid:2.16.578.1.12.4.1.1.8628" />
+      </binding>
+    </element>
+    <element id="Organization.type:organisatoriskNiva.coding.system">
+      <path value="Organization.type.coding.system" />
+      <min value="1" />
+      <fixedUri value="urn:oid:2.16.578.1.12.4.1.1.8628" />
+    </element>
+    <element id="Organization.type:organisatoriskNiva.coding.code">
+      <path value="Organization.type.coding.code" />
+      <min value="1" />
+    </element>
     <element id="Organization.address">
       <path value="Organization.address" />
       <type>

--- a/StructureDefinition/no-basis-Organization.structuredefinition-profile.xml
+++ b/StructureDefinition/no-basis-Organization.structuredefinition-profile.xml
@@ -6,7 +6,7 @@
     <lastUpdated value="2020-04-22T10:49:58.004+00:00" />
   </meta>
   <url value="http://hl7.no/fhir/StructureDefinition/no-basis-Organization" />
-  <version value="2.0.13" />
+  <version value="2.0.15" />
   <name value="NoBasisOrganization" />
   <title value="no-basis-Organization" />
   <status value="active" />
@@ -73,6 +73,7 @@
     <element id="Organization.type:organisatoriskNiva">
       <path value="Organization.type" />
       <sliceName value="organisatoriskNiva" />
+      <short value="Organisatorisk nivå" />
       <binding>
         <strength value="required" />
         <valueSet value="urn:oid:2.16.578.1.12.4.1.1.8628" />
@@ -84,6 +85,24 @@
       <fixedUri value="urn:oid:2.16.578.1.12.4.1.1.8628" />
     </element>
     <element id="Organization.type:organisatoriskNiva.coding.code">
+      <path value="Organization.type.coding.code" />
+      <min value="1" />
+    </element>
+    <element id="Organization.type:organisatoriskBetegnelse">
+      <path value="Organization.type" />
+      <sliceName value="organisatoriskBetegnelse" />
+      <short value="Organisatorisk betegnelse" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="urn:oid:2.16.578.1.12.4.1.1.8624" />
+      </binding>
+    </element>
+    <element id="Organization.type:organisatoriskBetegnelse.coding.system">
+      <path value="Organization.type.coding.system" />
+      <min value="1" />
+      <fixedUri value="urn:oid:2.16.578.1.12.4.1.1.8624" />
+    </element>
+    <element id="Organization.type:organisatoriskBetegnelse.coding.code">
       <path value="Organization.type.coding.code" />
       <min value="1" />
     </element>

--- a/StructureDefinition/no-basis-RelatedPerson.StructureDefinition-profile.xml
+++ b/StructureDefinition/no-basis-RelatedPerson.StructureDefinition-profile.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="no-basis-RelatedPerson" />
   <url value="http://hl7.no/fhir/StructureDefinition/no-basis-RelatedPerson" />
-  <version value="2.0.9" />
+  <version value="2.0.15" />
   <name value="NoBasisRelatedPerson" />
   <title value="no-basis-RelatedPerson" />
   <status value="active" />
@@ -77,7 +77,7 @@
     <element id="RelatedPerson.patient">
       <path value="RelatedPerson.patient" />
       <short value="The person this person is related to" />
-      <definition value="no-basis: Can reference no-basis-Patient in addition to Patient resources.&#xD;&#xA;&#xD;&#xA;The patient this person is related to." />
+      <definition value="no-basis: Can reference no-basis-Patient in addition to Patient resources. &#xD;&#xA;If a person reference is needed the optional extension should be used.&#xD;&#xA;&#xD;&#xA;The patient this person is related to." />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />

--- a/StructureDefinition/no-basis-RelatedPerson.StructureDefinition-profile.xml
+++ b/StructureDefinition/no-basis-RelatedPerson.StructureDefinition-profile.xml
@@ -77,13 +77,11 @@
     <element id="RelatedPerson.patient">
       <path value="RelatedPerson.patient" />
       <short value="The person this person is related to" />
-      <definition value="no-basis: Can reference no-basis-Patient, no-basis-Person or Person in addition to Patient resources.&#xD;&#xA;&#xD;&#xA;The patient this person is related to." />
+      <definition value="no-basis: Can reference no-basis-Patient in addition to Patient resources.&#xD;&#xA;&#xD;&#xA;The patient this person is related to." />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
         <targetProfile value="http://hl7.no/fhir/StructureDefinition/no-basis-Patient" />
-        <targetProfile value="http://hl7.no/fhir/StructureDefinition/no-basis-Person" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Person" />
       </type>
     </element>
     <element id="RelatedPerson.relationship">

--- a/StructureDefinition/no-basis-relatedperson-person-reference.StructureDefinition-extension..xml
+++ b/StructureDefinition/no-basis-relatedperson-person-reference.StructureDefinition-extension..xml
@@ -6,6 +6,7 @@
   <name value="NoBasisRelatedpersonPersonReference" />
   <status value="active" />
   <date value="2021-04-07" />
+  <description value="If a person reference is needed in RelatedPerson.patient element, this optional extension should be used." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -22,9 +23,25 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />
   <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Person reference in RelatedPerson.patient element" />
+      <definition value="If a person reference is needed in RelatedPerson.patient element, this optional extension should be used.&#xD;&#xA;The extension includes a reference to a single Person/no-basis-Person resource.&#xD;&#xA;&#xD;&#xA;To support searches for identifiers, an identifier value should be supported in addition to the literal reference." />
+      <comment value="no-basis currently (v2.0.15) don't include search parameter definition for this extension." />
+    </element>
     <element id="Extension.url">
       <path value="Extension.url" />
       <fixedUri value="http://ehelse.no/fhir/StructureDefinition/no-basis-relatedperson-person-reference" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <short value="Reference to person resource" />
+      <definition value="Reference to a single Person/no-basis-Person resource in RelatedPerson.patient element. &#xD;&#xA;Should only be used when a Person resource reference is needed.&#xD;&#xA;&#xD;&#xA;Name or identifier should be supplied in the RelatedPerson.patient element, in addition to information supplied in this extension." />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.no/fhir/StructureDefinition/no-basis-Person" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Person" />
+      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/StructureDefinition/no-basis-relatedperson-person-reference.StructureDefinition-extension..xml
+++ b/StructureDefinition/no-basis-relatedperson-person-reference.StructureDefinition-extension..xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="no-basis-relatedperson-person-reference" />
+  <url value="http://ehelse.no/fhir/StructureDefinition/no-basis-relatedperson-person-reference" />
+  <version value="2.0.15" />
+  <name value="NoBasisRelatedpersonPersonReference" />
+  <status value="active" />
+  <date value="2021-04-07" />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="RelatedPerson.patient" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://ehelse.no/fhir/StructureDefinition/no-basis-relatedperson-person-reference" />
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
HÅPER VI KAN ta FAST-TRACK for denne

Kompletterte versjon 2.0.15, manglet 8624 fra #69 og endringer for #42.

Når denne er pullet lager jeg ny pakke. Da har jeg også fikset noen foreldede dependencies på SIMPLIFIER som førte til valideringsfeil a-la: 
CodeInvalid : Code '4.0.1' from system '' does not exist in valueset 'http://hl7.org/fhir/ValueSet/FHIR-version'

* issue [#42](https://github.com/HL7Norway/basisprofiler-r4/issues/42)
* `no-basis-relatedperson-person-reference` Added extension to add person reference to the RelatedPerson.patient element
* `no-basis-RelatedPerson` Removed reference to no-basis-Person and Person from RelatedPerson.patient
* `no-basis-RelatedPerson-Ærlend-Sørgård-person-extension.xml` Added example to demonstrate the use of the new extension
* `no-basis-Organization` Added slices for 8624, issue [#69](https://github.com/HL7Norway/basisprofiler-r4/issues/69)

Closes #69 
Closes #42 
