### PR TITLE
Oppdatert dokumentasjon no-basis-Composition og no-basis-DocumentReference

### DIFF
--- a/StructureDefinition/no-basis-Composition.structuredefinition.xml
+++ b/StructureDefinition/no-basis-Composition.structuredefinition.xml
@@ -41,6 +41,7 @@
   <differential>
     <element id="Composition.type">
       <path value="Composition.type" />
+      <definition value="Specifies the particular kind of composition using the codes defined in the valueset 'NoBasisDocumentReferenceType'.&#xD;&#xA;Such as:&#xD;&#xA;- A00-1 Epikriser og sammenfatninger&#xD;&#xA;- A01-2 Kriseplan&#xD;&#xA;- A02-2 Individuell plan&#xD;&#xA;- etc.&#xD;&#xA;&#xD;&#xA;See valueset 'NoBasisDocumentReferenceType' in the Terminology section for more information on available types" />
       <binding>
         <strength value="required" />
         <valueSet value="http://hl7.no/fhir/ValueSet/no-basis-documentreference-type" />

--- a/StructureDefinition/no-basis-DocumentReference.structuredefinition-profile.xml
+++ b/StructureDefinition/no-basis-DocumentReference.structuredefinition-profile.xml
@@ -53,7 +53,7 @@
     <element id="DocumentReference.type">
       <path value="DocumentReference.type" />
       <short value="Kind of document" />
-      <definition value="Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note)." />
+      <definition value="Specifies the particular kind of document referenced using the codes defined in the valueset 'NoBasisDocumentReferenceType'.&#xD;&#xA;Such as:&#xD;&#xA;- A00-1 Epikriser og sammenfatninger&#xD;&#xA;- A01-2 Kriseplan&#xD;&#xA;- A02-2 Individuell plan&#xD;&#xA;- etc.&#xD;&#xA;&#xD;&#xA;See valueset 'NoBasisDocumentReferenceType' in the Terminology section for more information on available types" />
       <comment value="Key metadata element describing the document that describes the exact type of document. Helps humans to assess whether the document is of interest when viewing a list of documents." />
       <binding>
         <strength value="required" />


### PR DESCRIPTION
Oppdatert in-line dokumentasjon for attributtene Composition.type og DocumentReference.type

Composition.type:
```
Specifies the particular kind of composition using the codes defined in the valueset 'NoBasisDocumentReferenceType'.
Such as:
- A00-1 Epikriser og sammenfatninger
- A01-2 Kriseplan
- A02-2 Individuell plan
- etc.

See valueset 'NoBasisDocumentReferenceType' in the Terminology section for more information on available types
```

DocumentReference.type:
```
Specifies the particular kind of document referenced using the codes defined in the valueset 'NoBasisDocumentReferenceType'.
Such as:
- A00-1 Epikriser og sammenfatninger
- A01-2 Kriseplan
- A02-2 Individuell plan
- etc.

See valueset 'NoBasisDocumentReferenceType' in the Terminology section for more information on available types
```
Fixes #64 