### PR TITLE
Address PlantUML, fix the valueBoolean and no-basis-urban-district labels

### DIFF
--- a/images-source/address.plantuml
+++ b/images-source/address.plantuml
@@ -3,7 +3,7 @@
 class "no-basis-Address" as address
 class "no-basis-propertyInformation:extension" as property
 class "no-basis-address-official:extension" as official
-class "no-basisurban-district:extension" as urbandistrict
+class "no-basis-urban-district:extension" as urbandistrict
 class "no-basis-municipalitycode:extension" as municipality
 
 'package "FHIR DataTypes" #DDDDDD {
@@ -29,7 +29,7 @@ property : leaseholdNumber:int[0..*]
 property : condominiumUnitNumber:int[0..*]
 property : municipality:Coding[0..*]
 
-official : valeBoolean:boolean[0..1]
+official : valueBoolean:boolean[0..1]
 
 urbandistrict : valueCoding:Coding[0..1]
 


### PR DESCRIPTION
This fixes typos and readability in this [PlantUML diagram](https://thomiz.github.io/R5-fsh-no-basis/no-basis/CurrentBuild/Datatypes.html)  by following:
- valueBoolean (was misspelled)
- no-basis-urban-district (missing hyphen)
- Small layout tidy-up for clarity

I only changed source: images-source/address.plantuml.
And have not included any build artifacts. The visible diagram on Datatypes.html will update when the IG is rebuilt.

<img width="1321" height="779" alt="Datatype" src="https://github.com/user-attachments/assets/ba72e6e3-4ca8-4fa1-b5b9-42d105993537" />

This Addresses #120 (diagram clean-up for Datatypes page). Also the related PR is: R5-fsh-no-basis: thomiz/R5-fsh-no-basis#1 (NoBasisPatient citizenship binding fix)
